### PR TITLE
LPS-147933 Create POC for forcing certain actions to be production only (not just unsupported)

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/aop/CTTransactionAdvice.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/aop/CTTransactionAdvice.java
@@ -53,7 +53,10 @@ public class CTTransactionAdvice extends ChainableMethodAdvice {
 		CTAware ctAware = (CTAware)annotations.get(CTAware.class);
 
 		if (ctAware != null) {
-			if (ctAware.onProduction()) {
+			if (ctAware.productionOnly()) {
+				return CTMode.PRODUCTION_ONLY;
+			}
+			else if (ctAware.onProduction()) {
 				return CTMode.REQUIRES_NEW;
 			}
 
@@ -82,10 +85,22 @@ public class CTTransactionAdvice extends ChainableMethodAdvice {
 
 		CTMode ctMode = aopMethodInvocation.getAdviceMethodContext();
 
+		boolean requiresNew = false;
+
 		if ((ctMode == CTMode.REQUIRES_NEW) ||
 			(TransactionExecutorThreadLocal.getCurrentTransactionExecutor() ==
 				null)) {
 
+			requiresNew = true;
+		}
+
+		if (ctMode == CTMode.PRODUCTION_ONLY) {
+			throw new CTTransactionException(
+				"CT transaction validation failure. Nested operation using " +
+					aopMethodInvocation.getThis() +
+						" can only be performed in production mode.");
+		}
+		else if (requiresNew) {
 			try (SafeCloseable safeCloseable =
 					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
 						CTConstants.CT_COLLECTION_ID_PRODUCTION)) {
@@ -105,7 +120,7 @@ public class CTTransactionAdvice extends ChainableMethodAdvice {
 
 	private enum CTMode {
 
-		READ_ONLY, REQUIRES_NEW, STRICT
+		PRODUCTION_ONLY, READ_ONLY, REQUIRES_NEW, STRICT
 
 	}
 

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/aop/CTTransactionAdvice.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/aop/CTTransactionAdvice.java
@@ -19,10 +19,12 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.aop.AopMethodInvocation;
 import com.liferay.portal.kernel.aop.ChainableMethodAdvice;
 import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.change.tracking.CTAwareOnProductionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.CTTransactionException;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.spring.transaction.TransactionExecutor;
 import com.liferay.portal.spring.transaction.TransactionExecutorThreadLocal;
 
 import java.lang.annotation.Annotation;
@@ -57,7 +59,7 @@ public class CTTransactionAdvice extends ChainableMethodAdvice {
 				return CTMode.PRODUCTION_ONLY;
 			}
 			else if (ctAware.onProduction()) {
-				return CTMode.REQUIRES_NEW;
+				return CTMode.ON_PRODUCTION;
 			}
 
 			return null;
@@ -85,31 +87,29 @@ public class CTTransactionAdvice extends ChainableMethodAdvice {
 
 		CTMode ctMode = aopMethodInvocation.getAdviceMethodContext();
 
-		boolean requiresNew = false;
-
-		if ((ctMode == CTMode.REQUIRES_NEW) ||
-			(TransactionExecutorThreadLocal.getCurrentTransactionExecutor() ==
-				null)) {
-
-			requiresNew = true;
+		if (ctMode == CTMode.ON_PRODUCTION) {
+			CTAwareOnProductionThreadLocal.setOnProduction(true);
 		}
 
-		if (ctMode == CTMode.PRODUCTION_ONLY) {
-			throw new CTTransactionException(
-				"CT transaction validation failure. Nested operation using " +
-					aopMethodInvocation.getThis() +
-						" can only be performed in production mode.");
-		}
-		else if (requiresNew) {
-			try (SafeCloseable safeCloseable =
-					CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
-						CTConstants.CT_COLLECTION_ID_PRODUCTION)) {
+		if (ctMode != CTMode.PRODUCTION_ONLY) {
+			TransactionExecutor transactionExecutor =
+				TransactionExecutorThreadLocal.getCurrentTransactionExecutor();
 
+			if ((ctMode == CTMode.ON_PRODUCTION) ||
+				(ctMode == CTMode.REQUIRES_NEW) ||
+				(transactionExecutor == null)) {
+
+				try (SafeCloseable safeCloseable =
+						CTCollectionThreadLocal.
+							setCTCollectionIdWithSafeCloseable(
+								CTConstants.CT_COLLECTION_ID_PRODUCTION)) {
+
+					return aopMethodInvocation.proceed(arguments);
+				}
+			}
+			else if (ctMode == CTMode.READ_ONLY) {
 				return aopMethodInvocation.proceed(arguments);
 			}
-		}
-		else if (ctMode == CTMode.READ_ONLY) {
-			return aopMethodInvocation.proceed(arguments);
 		}
 
 		throw new CTTransactionException(
@@ -120,7 +120,7 @@ public class CTTransactionAdvice extends ChainableMethodAdvice {
 
 	private enum CTMode {
 
-		PRODUCTION_ONLY, READ_ONLY, REQUIRES_NEW, STRICT
+		ON_PRODUCTION, PRODUCTION_ONLY, READ_ONLY, REQUIRES_NEW, STRICT
 
 	}
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/CTAwareOnProductionAlertDynamicInclude.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/taglib/CTAwareOnProductionAlertDynamicInclude.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.change.tracking.web.internal.servlet.taglib;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.taglib.aui.ScriptTag;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Samuel Trong Tran
+ */
+@Component(service = DynamicInclude.class)
+public class CTAwareOnProductionAlertDynamicInclude extends BaseDynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		if (CTCollectionThreadLocal.isProductionMode() ||
+			!SessionMessages.contains(httpServletRequest, "onProduction")) {
+
+			return;
+		}
+
+		try {
+			ScriptTag scriptTag = new ScriptTag();
+
+			scriptTag.setPosition("inline");
+
+			scriptTag.doBodyTag(
+				httpServletRequest, httpServletResponse,
+				pageContext -> _processScriptTagBody(
+					httpServletRequest, pageContext));
+		}
+		catch (JspException jspException) {
+			ReflectionUtil.throwException(jspException);
+		}
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register("/html/common/themes/bottom.jsp#pre");
+	}
+
+	private void _processScriptTagBody(
+		HttpServletRequest httpServletRequest, PageContext pageContext) {
+
+		try {
+			Writer writer = pageContext.getOut();
+
+			writer.write(
+				"Liferay.Util.openToast({autoClose: 10000, message: '");
+
+			Locale locale = _portal.getLocale(httpServletRequest);
+
+			writer.write("Action was performed in production mode.");
+
+			writer.write("', title: '");
+
+			writer.write(_language.get(locale, "info"));
+
+			writer.write(":', type: 'info',});");
+		}
+		catch (IOException ioException) {
+			ReflectionUtil.throwException(ioException);
+		}
+	}
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyAccountPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/MyAccountPortlet.java
@@ -14,16 +14,22 @@
 
 package com.liferay.users.admin.web.internal.portlet;
 
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import java.io.IOException;
 
 import java.util.Objects;
 
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
 import javax.portlet.Portlet;
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
@@ -79,11 +85,29 @@ public class MyAccountPortlet extends MVCPortlet {
 		super.render(renderRequest, renderResponse);
 	}
 
+	@Override
+	protected boolean callActionMethod(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws PortletException {
+
+		SessionMessages.add(
+			_portal.getHttpServletRequest(actionRequest), "onProduction");
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(0)) {
+
+			return super.callActionMethod(actionRequest, actionResponse);
+		}
+	}
+
 	@Reference(
 		target = "(&(release.bundle.symbolic.name=com.liferay.users.admin.web)(&(release.schema.version>=1.0.0)(!(release.schema.version>=2.0.0))))",
 		unbind = "-"
 	)
 	protected void setRelease(Release release) {
 	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdatePasswordMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdatePasswordMVCActionCommand.java
@@ -15,6 +15,8 @@
 package com.liferay.users.admin.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.bean.BeanParamUtil;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.change.tracking.CTTransactionException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.UserPasswordException;
 import com.liferay.portal.kernel.model.Company;
@@ -63,6 +65,12 @@ public class UpdatePasswordMVCActionCommand extends BaseMVCActionCommand {
 	protected void doProcessAction(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
+
+		if (!CTCollectionThreadLocal.isProductionMode()) {
+			throw new CTTransactionException(
+				"CT transaction validation failure. Nested operation using " +
+					getClass() + " can only be performed in production mode.");
+		}
 
 		try {
 			ThemeDisplay themeDisplay =

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5451,6 +5451,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 *         bridge attributes for the user.
 	 * @return the user
 	 */
+	@CTAware(productionOnly = true)
 	@Override
 	public User updateUser(
 			long userId, String oldPassword, String newPassword1,
@@ -5786,6 +5787,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setOpenId(openId);
 
 		return userLocalService.updateUser(user);
+	}
+
+	@CTAware(productionOnly = true)
+	@Override
+	public User updateUser(User user) {
+		return super.updateUser(user);
 	}
 
 	/**

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 41.2.1
+Bundle-Version: 41.3.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTAware.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTAware.java
@@ -32,4 +32,6 @@ public @interface CTAware {
 
 	public boolean onProduction() default false;
 
+	public boolean productionOnly() default false;
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTAwareOnProductionThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/change/tracking/CTAwareOnProductionThreadLocal.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.change.tracking;
+
+import com.liferay.petra.lang.CentralizedThreadLocal;
+
+/**
+ * @author Preston Crary
+ */
+public class CTAwareOnProductionThreadLocal {
+
+	public static boolean isOnProduction() {
+		return _onProduction.get();
+	}
+
+	public static void setOnProduction(boolean onProduction) {
+		_onProduction.set(onProduction);
+	}
+
+	private CTAwareOnProductionThreadLocal() {
+	}
+
+	private static final CentralizedThreadLocal<Boolean> _onProduction =
+		new CentralizedThreadLocal<>(
+			CTAwareOnProductionThreadLocal.class + "._onProduction",
+			() -> Boolean.FALSE);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/change/tracking/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/change/tracking/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortlet.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.kernel.portlet;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.change.tracking.CTAwareOnProductionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.CTTransactionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -105,6 +106,12 @@ public class LiferayPortlet extends GenericPortlet {
 
 			if (isAddSuccessMessage(actionRequest)) {
 				addSuccessMessage(actionRequest, actionResponse);
+			}
+
+			if (CTAwareOnProductionThreadLocal.isOnProduction()) {
+				SessionMessages.add(
+					PortalUtil.getHttpServletRequest(actionRequest),
+					"onProduction");
 			}
 		}
 		catch (PortletException portletException) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -2742,6 +2742,7 @@ public interface UserLocalService
 	 bridge attributes for the user.
 	 * @return the user
 	 */
+	@CTAware(productionOnly = true)
 	public User updateUser(
 			long userId, String oldPassword, String newPassword1,
 			String newPassword2, boolean passwordReset,
@@ -2843,6 +2844,7 @@ public interface UserLocalService
 	 * @param user the user
 	 * @return the user that was updated
 	 */
+	@CTAware(productionOnly = true)
 	@Indexable(type = IndexableType.REINDEX)
 	public User updateUser(User user);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.1.1


### PR DESCRIPTION
FYI You'll likely have to deploy modules/core/portal-bootstrap to get it working.

2 major changes I made:
- Added production only tag, applied it to updateUser
- Added an alert toast when an onProduction (force) is used

My Account is a good area to focus exploration. Some considerations:
- Update password is onProduction, alert toast is shown
- Contacts and Announcements settings are currently forced to production silently (existing behavior, not using productionOnly tag)
- Other general changes to the user are blocked as unsupported (productionOnly on updateUser)

- If we go to an alert, we may need a way to make sure alerts always show. There are already some existing actions that can be done in a publication but that are forced to production, we need to make sure that doesn't happen silent, if we decide to always show an alert
- If we do a productionOnly flag, we should figure out a way to not throw an exception. It should be a warning at most, but certainly not an outright exception in the log.