### PR TITLE
Worsened performance when removing setCTCollectionIdWithSafeCloseable

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -29,8 +29,6 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -274,16 +272,7 @@ public class LayoutLocalServiceWrapper
 		ServiceContext currentServiceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		long ctCollectionId = sourceLayout.getCtCollectionId();
-
-		if (ctCollectionId == 0) {
-			ctCollectionId = targetLayout.getCtCollectionId();
-		}
-
-		try (SafeCloseable safeCloseable =
-				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
-					ctCollectionId)) {
-
+		try {
 			CopyLayoutThreadLocal.setCopyLayout(true);
 
 			User user = _getUser(


### PR DESCRIPTION
Hi @david-truong ,

Thank you very much for your help with this :heart: 

When I added the SaveCloseable when copying pages I detected a noticeable performance improvement, which led me to parameterize the testCopyLayoutContentWithPublication test so I could use it to quantify it. That test was previously in CopyLayoutContentTest and has now been changed to LayoutLocalServiceCopyLayoutContentTest.

Moving this logic to the services layer and removing SafeCloseable, I perceived a notable performance worsen. This led me to quantify it by parameterizing the test and with these results.

**LayoutLocalServiceCopyLayoutContentTest parametrization**

_NUMBER_FRAGMENT_ENTRY_LINKS = 25
_NUMBER_PAGES = 25

**testCopyLayoutContentWithPublication execution time with SafeCloseable**

![image](https://github.com/david-truong/liferay-portal/assets/84471361/5aaf0868-7050-4c19-b16c-7b6d22d065ce)


**testCopyLayoutContentWithPublication execution time without SafeCloseable**

![image](https://github.com/david-truong/liferay-portal/assets/84471361/7c8bd31a-0e18-4d2c-835c-2c80cbbd646d)


The worsening just with that change is very clear and consistent and I suspect that if we can understand what it is due to, it can help us greatly improve the publication's performance.

Thanks a lot!