### PR TITLE
LPD-1600 Rollback db changes with hypersonic

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -59,6 +59,8 @@ import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.CTColumnResolutionType;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -879,6 +881,41 @@ public class CTCollectionLocalServiceImpl
 				toCTCollectionId, entry.getKey(), entry.getValue());
 		}
 
+		if (DBManagerUtil.getDBType() == DBType.HYPERSONIC) {
+			relatedCTEntriesMap = _getRelatedCTEntriesMap(
+				toCTCollection, modelClassNameId, modelClassPK);
+
+			ctEntries = new ArrayList<>();
+
+			for (List<CTEntry> curCTEntries : relatedCTEntriesMap.values()) {
+				ctEntries.addAll(curCTEntries);
+			}
+
+			conflictInfoMap = checkConflicts(
+				fromCTCollection.getCompanyId(), ctEntries, toCTCollectionId,
+				toCTCollection.getName(),
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, "Production");
+
+			if (!conflictInfoMap.isEmpty()) {
+				Connection connection = _currentConnection.getConnection(
+					ctCollectionPersistence.getDataSource());
+
+				try {
+					connection.rollback();
+				}
+				catch (SQLException e) {
+					throw new RuntimeException(e);
+				}
+
+				throw new CTPublishConflictException("Conflict detected");
+			}
+
+			_ctClosureFactory.clearCache(fromCTCollectionId);
+			_ctClosureFactory.clearCache(toCTCollectionId);
+
+			return;
+		}
+
 		relatedCTEntriesMap = _getRelatedCTEntriesMap(
 			toCTCollection, modelClassNameId, modelClassPK);
 
@@ -1483,10 +1520,24 @@ public class CTCollectionLocalServiceImpl
 		Connection connection = _currentConnection.getConnection(
 			ctPersistence.getDataSource());
 
+		if (DBManagerUtil.getDBType() == DBType.HYPERSONIC) {
+			try {
+				connection.setAutoCommit(false);
+			}
+			catch (SQLException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				sb.toString())) {
 
 			preparedStatement.executeUpdate();
+
+			if (DBManagerUtil.getDBType() == DBType.HYPERSONIC) {
+				connection.commit();
+				connection.setAutoCommit(true);
+			}
 		}
 		catch (Exception exception) {
 			throw new SystemException(exception);
@@ -1499,6 +1550,11 @@ public class CTCollectionLocalServiceImpl
 					connection.prepareStatement(sb.toString())) {
 
 				preparedStatement.executeUpdate();
+
+				if (DBManagerUtil.getDBType() == DBType.HYPERSONIC) {
+					connection.commit();
+					connection.setAutoCommit(true);
+				}
 			}
 			catch (Exception exception) {
 				throw new SystemException(exception);


### PR DESCRIPTION
Hi Dave! Can you help me take a look at this?

I think the problem is that if MySQL runs into any errors during an update statement it triggers a rollback, ensuring the data. HSQL doesn't have that so updates need to be explicitly started and committed (or rolled back) if they run into any issues. 

[This block of code](https://github.com/liferay-publications/liferay-portal/pull/715/commits/c458776627d18938a4ffb1ddda7a520bfca3fa26) is checking for missing dependencies after moving the entries so if it fails in MySQL it rolls back but for HSQL it freezes.

The change I made is wrong because it creates a `javax.persistence.OptimisticLockException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : [com.liferay.change.tracking.model.impl.CTEntryImpl#1288]` when attempting to move a site but portal no longer freezes (baby step?) 

If I skip the second _relatedEntriesCheck with hypersonic then it causes a lot of NPE issues with the control panel in the publication that was partially moved