### PR TITLE
LPD-38392 Reindex the newly added documents

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/dto/v1_0/converter/CTEntryDTOConverter.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.IndexWriterHelper;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -112,6 +113,9 @@ public class CTEntryDTOConverter
 				com.liferay.change.tracking.model.CTEntry.class);
 
 		Document document = indexer.getDocument(ctEntry);
+
+		_indexWriterHelper.partiallyUpdateDocument(
+			ctEntry.getCompanyId(), document, indexer.isCommitImmediately());
 
 		return new CTEntry() {
 			{
@@ -224,6 +228,9 @@ public class CTEntryDTOConverter
 
 	@Reference
 	private IndexerRegistry _indexerRegistry;
+
+	@Reference
+	private IndexWriterHelper _indexWriterHelper;
 
 	@Reference
 	private Language _language;


### PR DESCRIPTION
The sort is working correctly but I think the ctEntries are reindexed after each ctEntry update. Now we are returning information on the ctCollectionId but I'm not sure when that information is indexed, so we could do a partial update/reindex of the ctEntry document