### PR TITLE
LPD-45208 Make sure to delete the layoutFriendlyURLEntry

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/model/listener/LayoutFriendlyURLModelListener.java
@@ -38,6 +38,19 @@ public class LayoutFriendlyURLModelListener
 	}
 
 	@Override
+	public void onAfterRemove(LayoutFriendlyURL layoutFriendlyURL) {
+		if (layoutFriendlyURL == null) {
+			return;
+		}
+
+		_friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+			layoutFriendlyURL.getGroupId(),
+			_layoutFriendlyURLEntryHelper.getClassNameId(
+				layoutFriendlyURL.isPrivateLayout()),
+			layoutFriendlyURL.getPlid());
+	}
+
+	@Override
 	public void onAfterUpdate(
 			LayoutFriendlyURL originalLayoutFriendlyURL,
 			LayoutFriendlyURL layoutFriendlyURL)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-45208

Prior to [this commit](https://github.com/brianchandotcom/liferay-portal/pull/157260/commits/e402a73832818d30d45a5f6f0318180d24936d09), a new asset entry associated to the FriendlyURLEntry was always created

If there is no asset related to the FriendlyURLEntry, the data isn't deleted properly. If we remove [this](https://github.com/liferay/liferay-portal/blob/master/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java#L262-L264), they get deleted but I think this can cause future problems if there is an asset associated with a FriendlyURLEntry.

A possible solution is to create an `onAfterRemove` in LayoutFriendlyURLModelListener that specifically deletes the layoutFriendlyURL.
