### PR TITLE
LPD-93910 Allow Publications Viewer to activate a publication

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -228,8 +228,7 @@ components:
             type: object
 info:
     description:
-        "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.change.tracking.rest.client', and version '6.0.3'."
+        "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '6.0.3'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -228,7 +228,8 @@ components:
             type: object
 info:
     description:
-        "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '6.0.3'."
+        "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
+        'com.liferay.change.tracking.rest.client', and version '6.0.3'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/CTCollectionResourceImpl.java
@@ -268,7 +268,7 @@ public class CTCollectionResourceImpl extends BaseCTCollectionResourceImpl {
 					}
 
 					return addAction(
-						ActionKeys.UPDATE, ctCollection.getCtCollectionId(),
+						ActionKeys.VIEW, ctCollection.getCtCollectionId(),
 						"postCTCollectionCheckout",
 						_ctCollectionModelResourcePermission);
 				}

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTPreferencesServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTPreferencesServiceImpl.java
@@ -59,7 +59,7 @@ public class CTPreferencesServiceImpl extends CTPreferencesServiceBaseImpl {
 			}
 
 			_ctCollectionModelResourcePermission.check(
-				getPermissionChecker(), ctCollection, ActionKeys.UPDATE);
+				getPermissionChecker(), ctCollection, ActionKeys.VIEW);
 		}
 
 		CTPreferences ctPreferences =

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTPreferencesServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTPreferencesServiceTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.change.tracking.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.model.CTPreferences;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.change.tracking.service.CTPreferencesService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Daniel de Freitas
+ */
+@RunWith(Arquillian.class)
+public class CTPreferencesServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+		_user = UserTestUtil.addGroupUser(_group, RoleConstants.SITE_MEMBER);
+
+		_roleLocalService.addUserRole(_user.getUserId(), _role);
+	}
+
+	@Test
+	public void testCheckoutCTCollectionWithViewPermission() throws Exception {
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), null);
+
+		_ctCollections.add(ctCollection);
+
+		RoleTestUtil.addResourcePermission(
+			_role, CTCollection.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(ctCollection.getCtCollectionId()), ActionKeys.VIEW);
+
+		UserTestUtil.setUser(_user);
+
+		CTPreferences ctPreferences =
+			_ctPreferencesService.checkoutCTCollection(
+				TestPropsValues.getCompanyId(), _user.getUserId(),
+				ctCollection.getCtCollectionId());
+
+		Assert.assertEquals(
+			ctCollection.getCtCollectionId(),
+			ctPreferences.getCtCollectionId());
+	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@DeleteAfterTestRun
+	private final List<CTCollection> _ctCollections = new ArrayList<>();
+
+	@Inject
+	private CTPreferencesService _ctPreferencesService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetSelectPublicationsMVCResourceCommand.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/portlet/action/GetSelectPublicationsMVCResourceCommand.java
@@ -13,7 +13,6 @@ import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.service.CTCollectionService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.change.tracking.web.internal.display.context.DisplayContextUtil;
-import com.liferay.change.tracking.web.internal.security.permission.resource.CTCollectionPermission;
 import com.liferay.change.tracking.web.internal.util.PublicationsPortletURLUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -24,7 +23,6 @@ import com.liferay.portal.kernel.model.UserTable;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -91,18 +89,12 @@ public class GetSelectPublicationsMVCResourceCommand
 
 			Date modifiedDate = ctCollection.getModifiedDate();
 
-			boolean readOnly = !CTCollectionPermission.contains(
-				themeDisplay.getPermissionChecker(), ctCollection,
-				ActionKeys.UPDATE);
-
 			JSONObject entryJSONObject = JSONUtil.put(
 				"description", ctCollection.getDescription()
 			).put(
 				"modifiedDate", modifiedDate.getTime()
 			).put(
 				"name", ctCollection.getName()
-			).put(
-				"readOnly", readOnly
 			).put(
 				"userId", ctCollection.getUserId()
 			).put(
@@ -113,9 +105,7 @@ public class GetSelectPublicationsMVCResourceCommand
 					String.valueOf(ctCollection.getCtCollectionId()))
 			);
 
-			if ((ctCollection.getCtCollectionId() != ctCollectionId) &&
-				!readOnly) {
-
+			if (ctCollection.getCtCollectionId() != ctCollectionId) {
 				entryJSONObject.put(
 					"checkoutURL",
 					PublicationsPortletURLUtil.getHref(

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
@@ -268,28 +268,6 @@ export default function ChangeTrackingIndicator({
 				</ClayList.ItemField>
 			);
 		}
-		else if (entry.readOnly) {
-			itemField = (
-				<ClayList.ItemField expand>
-					<ClayButton
-						data-tooltip-align="top"
-						disabled
-						displayType="unstyled"
-						title={Liferay.Language.get(
-							'you-do-not-have-permission-to-update-this-publication'
-						)}
-					>
-						<ClayList.ItemTitle>{entry.name}</ClayList.ItemTitle>
-
-						{!!entry.description && (
-							<ClayList.ItemText subtext>
-								{entry.description}
-							</ClayList.ItemText>
-						)}
-					</ClayButton>
-				</ClayList.ItemField>
-			);
-		}
 
 		dropdownItems.push({
 			label: Liferay.Language.get('review-changes'),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93910

## What Is Being Fixed

The Publications Viewer role grants only VIEW permission on a change tracking collection. Activating a publication (checking it out so it becomes the working publication) required UPDATE permission, so a user with the Publications Viewer role could not activate a publication or act on its workflow tasks. The publications picker also marked these collections read-only for such users.

## How It Is Being Fixed

The permission check for checking out a CT collection is lowered from UPDATE to VIEW in both CTPreferencesServiceImpl.checkoutCTCollection and the postCTCollectionCheckout action in CTCollectionResourceImpl. GetSelectPublicationsMVCResourceCommand no longer computes or emits the readOnly flag derived from UPDATE permission, and the corresponding read-only handling is removed from the ChangeTrackingIndicator component, so a viewer can select and activate any publication they can see. A new integration test, CTPreferencesServiceTest, verifies that a user holding only VIEW permission on a collection can check it out.

## PR Check

**pr-check: PASS** — tested on `be7ed885e344b4dd8ca93e5f4a16eafd54f525a0`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "be7ed885e344b4dd8ca93e5f4a16eafd54f525a0"} -->