### PR TITLE
Track the merge-base ant all last ran against

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
+++ b/modules/apps/portal-workflow/portal-workflow-api/src/main/java/com/liferay/portal/workflow/constants/WorkflowDefinitionConstants.java
@@ -46,6 +46,10 @@ public class WorkflowDefinitionConstants {
 			"L_MESSAGE_BOARDS_USER_STATS_MODERATION";
 
 	public static final String
+		EXTERNAL_REFERENCE_CODE_SEO_STUDIO_DESCRIPTION_GENERATOR =
+			"L_SEO_STUDIO_DESCRIPTION_GENERATOR";
+
+	public static final String
 		EXTERNAL_REFERENCE_CODE_SEO_STUDIO_TITLE_GENERATOR =
 			"L_SEO_STUDIO_TITLE_GENERATOR";
 
@@ -80,6 +84,9 @@ public class WorkflowDefinitionConstants {
 
 	public static final String NAME_PAGE_BUILDER = "Page Builder";
 
+	public static final String NAME_SEO_STUDIO_DESCRIPTION_GENERATOR =
+		"SEO Studio Description Generator";
+
 	public static final String NAME_SEO_STUDIO_TITLE_GENERATOR =
 		"SEO Studio Title Generator";
 
@@ -94,7 +101,7 @@ public class WorkflowDefinitionConstants {
 		NAME_FIX_SPELLING_AND_GRAMMAR, NAME_GENERATE_CONTENT,
 		NAME_GENERATE_IMAGE, NAME_IMPROVE_WRITING, NAME_LIFERAY_SEARCH,
 		NAME_MAKE_LONGER, NAME_MAKE_SHORTER, NAME_PAGE_BUILDER,
-		NAME_SEO_STUDIO_TITLE_GENERATOR
+		NAME_SEO_STUDIO_DESCRIPTION_GENERATOR, NAME_SEO_STUDIO_TITLE_GENERATOR
 	};
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentDefinitionResourceTest.java
@@ -1257,6 +1257,29 @@ public class AgentDefinitionResourceTest
 			new AgentDefinition() {
 				{
 					active = true;
+					externalReferenceCode =
+						"L_SEO_STUDIO_DESCRIPTION_GENERATOR";
+					inputVariables = new Variable[] {
+						new Variable() {
+							{
+								name = "pageContent";
+								type = "string";
+							}
+						}
+					};
+					outputVariable = new Variable() {
+						{
+							name = "metaDescription";
+							type = "string";
+						}
+					};
+					version = 1;
+					workflowDefinitionName = "SEO Studio Description Generator";
+				}
+			},
+			new AgentDefinition() {
+				{
+					active = true;
 					externalReferenceCode = "L_SEO_STUDIO_TITLE_GENERATOR";
 					inputVariables = new Variable[] {
 						new Variable() {

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer-test/src/testIntegration/java/com/liferay/ai/hub/site/initializer/internal/test/AIHubSiteInitializerTest.java
@@ -331,6 +331,11 @@ public class AIHubSiteInitializerTest {
 		_assertWorkflowDefinitionExists(
 			_ACCOUNT_EXTERNAL_REFERENCE_CODE_SEO_STUDIO,
 			WorkflowDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_SEO_STUDIO_DESCRIPTION_GENERATOR,
+			WorkflowDefinitionConstants.NAME_SEO_STUDIO_DESCRIPTION_GENERATOR);
+		_assertWorkflowDefinitionExists(
+			_ACCOUNT_EXTERNAL_REFERENCE_CODE_SEO_STUDIO,
+			WorkflowDefinitionConstants.
 				EXTERNAL_REFERENCE_CODE_SEO_STUDIO_TITLE_GENERATOR,
 			WorkflowDefinitionConstants.NAME_SEO_STUDIO_TITLE_GENERATOR);
 	}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-entries/agent-definition-object-entries.json
@@ -171,6 +171,19 @@
 		},
 		{
 			"active": true,
+			"description": "This agent analyzes the raw content of a webpage and generates an SEO-optimized meta description to fix a missing or empty description.",
+			"externalReferenceCode": "L_SEO_STUDIO_DESCRIPTION_GENERATOR",
+			"inputVariables": "pageContent",
+			"outputVariable": "metaDescription",
+			"r_accountToAIHubAgentDefinitions_accountEntryERC": "L_SEO_STUDIO",
+			"system": true,
+			"title_i18n": {
+				"en_US": "SEO Studio Description Generator"
+			},
+			"workflowDefinitionName": "SEO Studio Description Generator"
+		},
+		{
+			"active": true,
 			"description": "This agent analyzes the raw content of a webpage and generates an SEO-optimized HTML title tag to fix a missing or empty title.",
 			"externalReferenceCode": "L_SEO_STUDIO_TITLE_GENERATOR",
 			"inputVariables": "pageContent",

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-description-generator-workflow-definition/workflow-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-description-generator-workflow-definition/workflow-definition.json
@@ -1,0 +1,11 @@
+{
+	"active": true,
+	"externalReferenceCode": "L_SEO_STUDIO_DESCRIPTION_GENERATOR",
+	"groupExternalReferenceCode": "[$ACCOUNT_ENTRY_GROUP_ERC:L_SEO_STUDIO$]",
+	"name": "SEO Studio Description Generator",
+	"scope": "ai",
+	"title": "SEO Studio Description Generator",
+	"title_i18n": {
+		"en_US": "SEO Studio Description Generator"
+	}
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-description-generator-workflow-definition/workflow-definition.xml
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/workflow-definitions/seo-studio-description-generator-workflow-definition/workflow-definition.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0"?>
+
+<workflow-definition
+	xmlns="urn:liferay.com:liferay-workflow_7.4.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="urn:liferay.com:liferay-workflow_7.4.0 http://www.liferay.com/dtd/liferay-workflow-definition_7_4_0.xsd"
+>
+	<name>SEO Studio Description Generator</name>
+	<version>1</version>
+	<llm>
+		<name>seoStudioDescriptionGenerator</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						276,
+						242
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				SEO Studio Description Generator
+			</label>
+		</labels>
+		<input-variables>
+			<![CDATA[
+				[
+					{
+						"name": "pageContent",
+						"type": "string"
+					}
+				]
+			]]>
+		</input-variables>
+		<output-variables>
+			<![CDATA[
+				[
+					{
+						"name": "metaDescription",
+						"type": "string"
+					}
+				]
+			]]>
+		</output-variables>
+		<prompt>
+			<![CDATA[You are an expert SEO Specialist. Your task is to analyze the raw content of a webpage and generate optimized meta description candidates to fix a missing or empty description.
+
+SEO CONSTRAINTS & RULES:
+- Length: Each candidate must be between 120 and 160 characters.
+- Content: Summarize the core intent of the page in one or two sentences, naturally including the primary topic/keyword. Do not stuff keywords.
+- Style: Write in active voice. Avoid generic phrasing like "Welcome to our website". When it reads naturally, end with a soft call to action.
+- Provide 1 to 3 distinct candidates, each with a short rationale explaining why it fits the page.
+
+OUTPUT FORMAT:
+Return ONLY a JSON object shaped {"candidates":[{"title":"...","rationale":"..."}]}. The "title" field holds the candidate meta description text.
+Do not include any introductory text, markdown formatting (like ```json), or conversational explanations.
+Example of acceptable output:
+{"candidates":[{"title":"Discover our range of espresso machines built for home brewing, from entry-level models to professional-grade equipment—find the right fit for your kitchen today.","rationale":"Leads with the primary keyword and includes a call to action."}]}]]>
+		</prompt>
+		<tools>
+			<![CDATA[[]]]>
+		</tools>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						End
+					</label>
+				</labels>
+				<name>end</name>
+				<target>end</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+		<user-message>
+			<![CDATA[Page Content: {{pageContent}}]]>
+		</user-message>
+	</llm>
+	<state>
+		<name>start</name>
+		<metadata>
+			<![CDATA[
+				{
+					"xy": [
+						273,
+						25
+					]
+				}
+			]]>
+		</metadata>
+		<initial>true</initial>
+		<labels>
+			<label language-id="en_US">
+				Start
+			</label>
+		</labels>
+		<transitions>
+			<transition>
+				<labels>
+					<label language-id="en_US">
+						SEO Studio Description Generator
+					</label>
+				</labels>
+				<name>seoStudioDescriptionGenerator</name>
+				<target>seoStudioDescriptionGenerator</target>
+				<default>true</default>
+			</transition>
+		</transitions>
+	</state>
+	<state>
+		<name>end</name>
+		<metadata>
+			<![CDATA[
+				{
+					"terminal": true,
+					"xy": [
+						277,
+						459
+					]
+				}
+			]]>
+		</metadata>
+		<labels>
+			<label language-id="en_US">
+				End
+			</label>
+		</labels>
+	</state>
+</workflow-definition>


### PR DESCRIPTION
## Summary
- Persist the merge-base between HEAD and master alongside each worktree's slot state (`~/.liferay-cli/worktrees/<id>/build_base.json`) whenever "ant all" completes — via `liferay build` (bare) or `liferay worktree add`.
- `liferay build <module ...>` now warns to stderr if that base has moved since the last full build, so a rebase that pulled in core changes isn't silently missed by a module-only deploy.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/state/... ./internal/cli/...`
- [x] `gofmt -l` / `go vet ./...` clean